### PR TITLE
Add assertion that options are of the correct form.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -45,6 +45,7 @@ let assert = require('assert');
  * `undefined`, so it can fall-back to defaults from previous config file.
  */
 let config = (options) => {
+  assert(options instanceof Object, "Options must be an object!");
   options = _.defaults({}, options, {
     files: [
       'config.yml',

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -150,4 +150,10 @@ suite("config", function() {
       list:       ["abc", "def", "qouted string", ""]
     });
   });
+
+  test("yell when options are wrong format", () => {
+    assume(() => {
+      config('oops');
+    }).throws("Options must be an object!");
+  });
 });


### PR DESCRIPTION
Otherwise, if you passed in a string, things "worked" but failed in mysterious and hard-to-debug ways.